### PR TITLE
Correct percentiles

### DIFF
--- a/R/verify_spatial.R
+++ b/R/verify_spatial.R
@@ -444,7 +444,7 @@ verify_spatial <- function(dttm,
         myargs <- list(obfield=obfield, fcfield=fcfield,
                          thresholds = thresholds,
                          scales = window_sizes,
-			 percentiles, percentiles)
+			 percentiles = percentiles)
         message("--> Calling ", sf)
         multiscore <- do.call(sf, myargs)
 


### PR DESCRIPTION
Came across this issue when using the ACCORD_VS_202406 setup for SAL, which fails as the min_rain argument takes percentiles from myargs.